### PR TITLE
update cart api path

### DIFF
--- a/src/constants/apiPaths.ts
+++ b/src/constants/apiPaths.ts
@@ -3,7 +3,7 @@ const API_PATHS = {
   order: "https://.execute-api.eu-west-1.amazonaws.com/dev",
   import: "https://bne9kotxl5.execute-api.eu-central-1.amazonaws.com/prod",
   bff: "https://.execute-api.eu-west-1.amazonaws.com/dev",
-  cart: "https://efe74dtc53.execute-api.eu-central-1.amazonaws.com/prod/api",
+  cart: "https://x7q4i11dkj.execute-api.eu-central-1.amazonaws.com/api",
 };
 
 export default API_PATHS;


### PR DESCRIPTION
What was done:

- [x] Update cart api path

!!! Api Gateway url  https://x7q4i11dkj.execute-api.eu-central-1.amazonaws.com/ that proxies the reqs to Elastic Beanstalk (which is http) is used to avoid "Mixed content" error.
The Elastic Beanstalk url - http://ekaterinahubkina-cart-api-prod.eu-central-1.elasticbeanstalk.com/

 [Web Page url](https://d19abc31vx8vrv.cloudfront.net/)

[BE PR](https://github.com/ekaterinahubkina/nodejs-aws-cart-api/pull/2)